### PR TITLE
remove space from microtime

### DIFF
--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -29,7 +29,7 @@ class TemporaryDirectory
         }
 
         if (empty($this->name)) {
-            $this->name = microtime();
+            $this->name = str_replace(' ', '', microtime());
         }
 
         if ($this->forceCreate && file_exists($this->getFullPath())) {

--- a/tests/TemporaryDirectoryTest.php
+++ b/tests/TemporaryDirectoryTest.php
@@ -46,6 +46,14 @@ class TemporaryDirectoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_does_not_generate_spaces_in_directory_path()
+    {
+        $temporaryDirectory = (new TemporaryDirectory())->create();
+
+        $this->assertEquals(0, substr_count($temporaryDirectory->path(), ' '));
+    }
+
+    /** @test */
     public function it_can_create_a_temporary_directory_in_a_custom_location()
     {
         $temporaryDirectory = (new TemporaryDirectory())


### PR DESCRIPTION
As noted in [this issue](https://github.com/spatie/laravel-backup/issues/358), the temporary directory that is generated contains a space which causes failures on some operating systems.