### PR TITLE
Add rand function for name of temporary directory

### DIFF
--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -28,7 +28,7 @@ class TemporaryDirectory
         }
 
         if (empty($this->name)) {
-            $this->name = str_replace([' ', '.'], '', microtime());
+            $this->name = rand().str_replace([' ', '.'], '', microtime());
         }
 
         if ($this->forceCreate && file_exists($this->getFullPath())) {


### PR DESCRIPTION
Hello,

I use spatie/browsershot and spatie/async. 

In some case browsershot crash and output the error below: 

```
Spatie\Async\Output\ParallelError: PHP Warning:  mkdir(): File exists in /var/www/admin/releases/20190510160712/vendor/spatie/temporary-directory/src/TemporaryDirectory.php on line 42
```
This error is frequent when the concurrent process is high.

After some test, the problem occurs because at least 2 processes try to create a temporary directory at same time.

For resolve this issue, I have concatenate a random numbers with a timestamp generated by microtime function :

```
if (empty($this->name)) {
      $this->name = rand().str_replace([' ', '.'], '', microtime());
}
```

Tell me if there are a better solution for this problem.

Thank's.