### PR TITLE
Delete directories using FilesystemIterator

### DIFF
--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -3,6 +3,7 @@
 namespace Spatie\TemporaryDirectory;
 
 use Exception;
+use FilesystemIterator;
 use InvalidArgumentException;
 
 class TemporaryDirectory
@@ -150,12 +151,8 @@ class TemporaryDirectory
             return unlink($path);
         }
 
-        foreach (scandir($path) as $item) {
-            if ($item == '.' || $item == '..') {
-                continue;
-            }
-
-            if (! $this->deleteDirectory($path.DIRECTORY_SEPARATOR.$item)) {
+        foreach (new FilesystemIterator($path) as $item) {
+            if (! $this->deleteDirectory($item)) {
                 return false;
             }
         }

--- a/tests/TemporaryDirectoryTest.php
+++ b/tests/TemporaryDirectoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\TemporaryDirectory\Test;
 
+use FilesystemIterator;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
@@ -259,12 +260,8 @@ class TemporaryDirectoryTest extends TestCase
             return unlink($path);
         }
 
-        foreach (scandir($path) as $item) {
-            if ($item == '.' || $item == '..') {
-                continue;
-            }
-
-            if (! $this->deleteDirectory($path.DIRECTORY_SEPARATOR.$item)) {
+        foreach (new FilesystemIterator($path) as $item) {
+            if (! $this->deleteDirectory($item)) {
                 return false;
             }
         }


### PR DESCRIPTION
The `FilesystemIterator` class is part of `Standard PHP Library` (*SPL*) which is available and compiled by default in PHP 5.0.0.