### PR TITLE
apply some tests improvements

### DIFF
--- a/tests/TemporaryDirectoryTest.php
+++ b/tests/TemporaryDirectoryTest.php
@@ -98,7 +98,7 @@ class TemporaryDirectoryTest extends TestCase
         $this->assertStringEndsNotWith(DIRECTORY_SEPARATOR, $temporaryDirectory->path());
 
         $temporaryDirectory = (new TemporaryDirectory())
-            ->location($this->temporaryDirectory.DIRECTORY_SEPARATOR)
+            ->location($this->testingDirectory.DIRECTORY_SEPARATOR)
             ->create();
 
         $this->assertStringEndsNotWith(DIRECTORY_SEPARATOR, $temporaryDirectory->path());
@@ -121,12 +121,19 @@ class TemporaryDirectoryTest extends TestCase
     {
         mkdir($this->temporaryDirectoryFullPath);
 
+        $testFile = $this->temporaryDirectoryFullPath . DIRECTORY_SEPARATOR . 'test.txt';
+
+        touch($testFile);
+
+        $this->assertFileExists($testFile);
+
         (new TemporaryDirectory())
             ->force()
             ->name($this->temporaryDirectory)
             ->create();
 
         $this->assertDirectoryExists($this->temporaryDirectoryFullPath);
+        $this->assertFileNotExists($testFile);
     }
 
     /** @test */


### PR DESCRIPTION
It seems to me that the `force()` method isn't being properly tested.

For instance, even when then following block of code inside `it_will_overwrite_an_existing_directory_when_using_force_create` is commented, test still passes:

```php
(new TemporaryDirectory())
    ->force()
    ->name($this->temporaryDirectory)
    ->create();
```

This PR solves this 'bug' by ensuring that a file created inside a temporary directory doesn't exist anymore after the use of the `force()` method.

This PR also modifies the `it_strips_trailing_slashes_from_a_location` test in such a manner that the `location()` method uses the same parameter used by the constructor.

By doing that way, all temporary directories that were created by the test suite are removed after tests execution.