### PR TITLE
Delete temporary directories with broken symlinks.

### DIFF
--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -143,6 +143,10 @@ class TemporaryDirectory
 
     protected function deleteDirectory(string $path): bool
     {
+        if (is_link($path)) {
+            return unlink($path);
+        }
+
         if (! file_exists($path)) {
             return true;
         }

--- a/tests/TemporaryDirectoryTest.php
+++ b/tests/TemporaryDirectoryTest.php
@@ -224,6 +224,23 @@ class TemporaryDirectoryTest extends TestCase
     }
 
     /** @test */
+    public function it_can_delete_a_temporary_directory_containing_broken_symlink()
+    {
+        $temporaryDirectory = (new TemporaryDirectory())
+            ->name($this->temporaryDirectory)
+            ->create();
+
+        symlink(
+            $temporaryDirectory->path().DIRECTORY_SEPARATOR.'target',
+            $temporaryDirectory->path().DIRECTORY_SEPARATOR.'link'
+        );
+
+        $temporaryDirectory->delete();
+
+        $this->assertDirectoryNotExists($this->temporaryDirectoryFullPath);
+    }
+
+    /** @test */
     public function it_can_empty_a_temporary_directory()
     {
         $temporaryDirectory = (new TemporaryDirectory())
@@ -259,6 +276,10 @@ class TemporaryDirectoryTest extends TestCase
 
     protected function deleteDirectory(string $path): bool
     {
+        if (is_link($path)) {
+            return unlink($path);
+        }
+
         if (! file_exists($path)) {
             return true;
         }


### PR DESCRIPTION
This change handles a case where a temporary directory could not be deleted because it contained a symlink to a non-existing file.

The issue is that `file_exists()` returns false for broken symlinks. This in turn means that method `deleteDirectory()` will skip the broken symlink and then fail at `rmdir()` because directory is not actually empty.