### PR TITLE
Improve PHPUnit fixture and ignore cached result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 composer.lock
 docs
 vendor
+.phpunit.result.cache

--- a/tests/TemporaryDirectoryTest.php
+++ b/tests/TemporaryDirectoryTest.php
@@ -18,7 +18,7 @@ class TemporaryDirectoryTest extends TestCase
     /** @var string */
     protected $temporaryDirectoryFullPath;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
# Changed log

- Improve PHPUnit fixture.
- The `.phpunit.result.cache` file is generated by `PHPUnit` and it should be ignored on Git version control.