### PR TITLE
Add PHP 8-only Support (v2)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,3 @@
-; This file is for unifying the coding style for different editors and IDEs.
-; More information at http://editorconfig.org
-
 root = true
 
 [*]
@@ -13,3 +10,6 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,9 +4,9 @@
 # Ignore all test and documentation with "export-ignore".
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
-/.editorconfig      export-ignore
-/.travis.yml        export-ignore
 /phpunit.xml.dist   export-ignore
-/.scrutinizer.yml   export-ignore
-/.styleci.yml       export-ignore
 /tests              export-ignore
+/.editorconfig      export-ignore
+/.php_cs            export-ignore
+/.github            export-ignore
+/psalm.xml          export-ignore

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: spatie
+custom: https://spatie.be/open-source/support-us

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+If you discover any security related issues, please email freek@spatie.be instead of using the issue tracker.

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,21 +9,10 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.0, 7.4, 7.3, 7.2]
-                laravel: [8.*, 7.*, 6.*]
+                php: [8.0]
                 dependency-version: [prefer-lowest, prefer-stable]
-                include:
-                    -   laravel: 8.*
-                        testbench: 6.*
-                    -   laravel: 7.*
-                        testbench: 5.*
-                    -   laravel: 6.*
-                        testbench: 4.*
-                exclude:
-                    -   laravel: 8.*
-                        php: 7.2
 
-        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+        name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
         steps:
             -   name: Checkout code
@@ -33,7 +22,7 @@ jobs:
                 uses: actions/cache@v1
                 with:
                     path: ~/.composer/cache/files
-                    key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+                    key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -43,8 +32,7 @@ jobs:
                     coverage: none
 
             -   name: Install dependencies
-                run: |
-                    composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-                    composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+                run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+
             -   name: Execute tests
                 run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,4 +35,4 @@ jobs:
                 run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
             -   name: Execute tests
-                run: vendor/bin/phpunit
+                run: vendor/bin/phpunit --no-coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
+.idea
+.php_cs
+.php_cs.cache
+.phpunit.result.cache
 build
 composer.lock
+coverage
 docs
+phpunit.xml
+psalm.xml
 vendor
-.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `temporary-directory` will be documented in this file
 
+## 2.0.0 - unreleased
+
+- require PHP 8+
+- drop PHP 7.x support
+- use PHP 8 syntax
+- use custom exception classes instead of `InvalidArgumentException` and `Exception`
+
 ## 1.3.0 - 2020-11-09
 
 - support for PHP 8 (#44)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Quickly create, use and delete temporary directories
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/temporary-directory.svg?style=flat-square)](https://packagist.org/packages/spatie/temporary-directory)
-![Tests](https://github.com/spatie/temporary-directory/workflows/run-tests/badge.svg)
+![Tests](https://github.com/spatie/temporary-directory/workflows/run-tests/badge.svg?label=tests)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/temporary-directory.svg?style=flat-square)](https://packagist.org/packages/spatie/temporary-directory)
 
@@ -108,23 +108,23 @@ Once you're done processing your temporary data you can delete the entire tempor
 $temporaryDirectory->delete();
 ```
 
+## Testing
+
+```bash
+composer test
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
-
-## Testing
-
-``` bash
-composer test
-```
 
 ## Contributing
 
 Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for details.
 
-## Security
+## Security Vulnerabilities
 
-If you discover any security related issues, please email freek@spatie.be instead of using the issue tracker.
+Please review [our security policy](../../security/policy) on how to report security vulnerabilities.
 
 ## Postcardware
 

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0"
+        "php": "^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0|^9.0"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {
@@ -33,9 +33,12 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpunit"
+        "test": "vendor/bin/phpunit",
+        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
     },
     "config": {
         "sort-packages": true
-  }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    executionOrder="random"
+    failOnWarning="true"
+    failOnRisky="true"
+    failOnEmptyTestSuite="true"
+    beStrictAboutOutputDuringTests="true"
+    verbose="true"
+>
     <testsuites>
         <testsuite name="Spatie Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+        <report>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
+    <logging>
+        <junit outputFile="build/report.junit.xml"/>
+    </logging>
 </phpunit>

--- a/src/Exceptions/InvalidDirectoryName.php
+++ b/src/Exceptions/InvalidDirectoryName.php
@@ -6,6 +6,6 @@ class InvalidDirectoryName extends \Exception
 {
     public static function create(string $directoryName): static
     {
-        return new static("The directory name `{$name}` contains invalid characters.");
+        return new static("The directory name `{$directoryName}` contains invalid characters.");
     }
 }

--- a/src/Exceptions/InvalidDirectoryName.php
+++ b/src/Exceptions/InvalidDirectoryName.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\TemporaryDirectory\Exceptions;
+
+class InvalidDirectoryName extends \Exception
+{
+    public static function create(string $directoryName): static
+    {
+        return new static("The directory name `{$name}` contains invalid characters.");
+    }
+}

--- a/src/Exceptions/PathAlreadyExists.php
+++ b/src/Exceptions/PathAlreadyExists.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\TemporaryDirectory\Exceptions;
+
+class PathAlreadyExists extends \Exception
+{
+    public static function create(string $path): static
+    {
+        return new static("Path `{$path}` already exists.");
+    }
+}

--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -8,14 +8,11 @@ use InvalidArgumentException;
 
 class TemporaryDirectory
 {
-    /** @var string */
-    protected $location;
+    protected string $location;
 
-    /** @var string */
-    protected $name;
+    protected string $name = '';
 
-    /** @var bool */
-    protected $forceCreate = false;
+    protected bool $forceCreate = false;
 
     public function __construct(string $location = '')
     {
@@ -86,6 +83,7 @@ class TemporaryDirectory
     public function empty(): self
     {
         $this->deleteDirectory($this->getFullPath());
+
         mkdir($this->getFullPath(), 0777, true);
 
         return $this;
@@ -138,7 +136,7 @@ class TemporaryDirectory
 
     protected function isFilePath(string $path): bool
     {
-        return strpos($path, '.') !== false;
+        return str_contains($path, '.');
     }
 
     protected function deleteDirectory(string $path): bool

--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -5,6 +5,8 @@ namespace Spatie\TemporaryDirectory;
 use Exception;
 use FilesystemIterator;
 use InvalidArgumentException;
+use Spatie\TemporaryDirectory\Exceptions\InvalidDirectoryName;
+use Spatie\TemporaryDirectory\Exceptions\PathAlreadyExists;
 
 class TemporaryDirectory
 {
@@ -34,7 +36,7 @@ class TemporaryDirectory
         }
 
         if (file_exists($this->getFullPath())) {
-            throw new InvalidArgumentException("Path `{$this->getFullPath()}` already exists.");
+            throw PathAlreadyExists::create($this->getFullPath());
         }
 
         mkdir($this->getFullPath(), 0777, true);
@@ -119,7 +121,7 @@ class TemporaryDirectory
     protected function sanitizeName(string $name): string
     {
         if (! $this->isValidDirectoryName($name)) {
-            throw new Exception("The directory name `$name` contains invalid characters.");
+            throw InvalidDirectoryName::create($name);
         }
 
         return trim($name);

--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -2,9 +2,7 @@
 
 namespace Spatie\TemporaryDirectory;
 
-use Exception;
 use FilesystemIterator;
-use InvalidArgumentException;
 use Spatie\TemporaryDirectory\Exceptions\InvalidDirectoryName;
 use Spatie\TemporaryDirectory\Exceptions\PathAlreadyExists;
 
@@ -98,7 +96,7 @@ class TemporaryDirectory
 
     protected function getFullPath(): string
     {
-        return $this->location.($this->name ? DIRECTORY_SEPARATOR.$this->name : '');
+        return $this->location.(! empty($this->name) ? DIRECTORY_SEPARATOR.$this->name : '');
     }
 
     protected function isValidDirectoryName(string $directoryName): bool

--- a/tests/TemporaryDirectoryTest.php
+++ b/tests/TemporaryDirectoryTest.php
@@ -3,8 +3,9 @@
 namespace Spatie\TemporaryDirectory\Test;
 
 use FilesystemIterator;
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Spatie\TemporaryDirectory\Exceptions\InvalidDirectoryName;
+use Spatie\TemporaryDirectory\Exceptions\PathAlreadyExists;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 
 class TemporaryDirectoryTest extends TestCase
@@ -106,7 +107,7 @@ class TemporaryDirectoryTest extends TestCase
     {
         mkdir($this->temporaryDirectoryFullPath);
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(PathAlreadyExists::class);
 
         (new TemporaryDirectory())
             ->name($this->temporaryDirectory)
@@ -256,7 +257,7 @@ class TemporaryDirectoryTest extends TestCase
     /** @test */
     public function it_throws_exception_on_invalid_name()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(InvalidDirectoryName::class);
         $this->expectExceptionMessage('The directory name `/` contains invalid characters.');
         $temporaryDirectory = (new TemporaryDirectory())
             ->name('/');

--- a/tests/TemporaryDirectoryTest.php
+++ b/tests/TemporaryDirectoryTest.php
@@ -9,14 +9,11 @@ use Spatie\TemporaryDirectory\TemporaryDirectory;
 
 class TemporaryDirectoryTest extends TestCase
 {
-    /** @var string */
-    protected $temporaryDirectory = 'temporary_directory';
+    protected string $temporaryDirectory = 'temporary_directory';
 
-    /** @var string */
-    protected $testingDirectory = __DIR__.DIRECTORY_SEPARATOR.'temp';
+    protected string $testingDirectory = __DIR__.DIRECTORY_SEPARATOR.'temp';
 
-    /** @var string */
-    protected $temporaryDirectoryFullPath;
+    protected string $temporaryDirectoryFullPath;
 
     protected function setUp(): void
     {
@@ -133,7 +130,7 @@ class TemporaryDirectoryTest extends TestCase
             ->create();
 
         $this->assertDirectoryExists($this->temporaryDirectoryFullPath);
-        $this->assertFileNotExists($testFile);
+        $this->assertFileDoesNotExist($testFile);
     }
 
     /** @test */
@@ -208,7 +205,7 @@ class TemporaryDirectoryTest extends TestCase
         touch($subdirectoryPath);
         $temporaryDirectory->delete();
 
-        $this->assertDirectoryNotExists($this->temporaryDirectoryFullPath);
+        $this->assertDirectoryDoesNotExist($this->temporaryDirectoryFullPath);
     }
 
     /** @test */
@@ -220,7 +217,7 @@ class TemporaryDirectoryTest extends TestCase
 
         $temporaryDirectory->delete();
 
-        $this->assertDirectoryNotExists($this->temporaryDirectoryFullPath);
+        $this->assertDirectoryDoesNotExist($this->temporaryDirectoryFullPath);
     }
 
     /** @test */
@@ -237,7 +234,7 @@ class TemporaryDirectoryTest extends TestCase
 
         $temporaryDirectory->delete();
 
-        $this->assertDirectoryNotExists($this->temporaryDirectoryFullPath);
+        $this->assertDirectoryDoesNotExist($this->temporaryDirectoryFullPath);
     }
 
     /** @test */
@@ -252,7 +249,7 @@ class TemporaryDirectoryTest extends TestCase
         touch($subdirectoryPath);
         $temporaryDirectory->empty();
 
-        $this->assertFileNotExists($this->temporaryDirectoryFullPath.DIRECTORY_SEPARATOR.$subdirectoriesWithFile);
+        $this->assertFileDoesNotExist($this->temporaryDirectoryFullPath.DIRECTORY_SEPARATOR.$subdirectoriesWithFile);
         $this->assertDirectoryExists($this->temporaryDirectoryFullPath);
     }
 


### PR DESCRIPTION
This PR adds a new major version, v2.0.0.

Specifically, it:

- Removes support for all PHP 7.x versions.
- Requires PHP 8.0+.
- All syntax converted to PHP 8 where possible.
- Removes unnecessary PHP docblocks per Spatie's guidelines.
- Adds/implements custom Exception classes to match the structure of other packages.
- Removes unnecessary Laravel configuration in `run-tests` workflow.
- Adds/updates several files from `spatie/package-skeleton-php`.
- Updates the use of several deprecated assertion methods to new method names in the unit tests.
- _Updates the changelog - release date needs to be updated, currently is "unreleased"._