### PR TITLE
Executes code and deletes directory automatically

### DIFF
--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -42,6 +42,13 @@ class TemporaryDirectory
         return $this;
     }
 
+    public function execute(callable $callable): bool
+    {
+        $callable($this);
+
+        return $this->delete();
+    }
+
     public function force(): self
     {
         $this->forceCreate = true;

--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -44,6 +44,8 @@ class TemporaryDirectory
 
     public function execute(callable $callable): bool
     {
+        $this->create();
+
         $callable($this);
 
         return $this->delete();

--- a/tests/TemporaryDirectoryTest.php
+++ b/tests/TemporaryDirectoryTest.php
@@ -40,7 +40,6 @@ class TemporaryDirectoryTest extends TestCase
         $temporaryPath = '';
 
         $result = (new TemporaryDirectory())
-            ->create()
             ->execute(function (TemporaryDirectory $temporaryDirectory) use (&$temporaryPath) {
                 $this->assertDirectoryExists($temporaryPath = $temporaryDirectory->path());
             });
@@ -68,7 +67,6 @@ class TemporaryDirectoryTest extends TestCase
 
         $result = (new TemporaryDirectory())
             ->name($this->temporaryDirectory)
-            ->create()
             ->execute(function (TemporaryDirectory $temporaryDirectory) use (&$temporaryPath) {
                 $this->assertDirectoryExists($temporaryPath = $temporaryDirectory->path());
                 $this->assertDirectoryExists($this->temporaryDirectoryFullPath);

--- a/tests/TemporaryDirectoryTest.php
+++ b/tests/TemporaryDirectoryTest.php
@@ -35,6 +35,22 @@ class TemporaryDirectoryTest extends TestCase
     }
 
     /** @test */
+    public function it_can_create_a_temporary_directory_using_execute()
+    {
+        $temporaryPath = '';
+
+        $result = (new TemporaryDirectory())
+            ->create()
+            ->execute(function (TemporaryDirectory $temporaryDirectory) use (&$temporaryPath) {
+                $this->assertDirectoryExists($temporaryPath = $temporaryDirectory->path());
+            });
+
+        $this->assertTrue($result);
+        $this->assertNotEmpty($temporaryPath);
+        $this->assertDirectoryDoesNotExist($temporaryPath);
+    }
+
+    /** @test */
     public function it_can_create_a_temporary_directory_with_a_name()
     {
         $temporaryDirectory = (new TemporaryDirectory())
@@ -43,6 +59,25 @@ class TemporaryDirectoryTest extends TestCase
 
         $this->assertDirectoryExists($temporaryDirectory->path());
         $this->assertDirectoryExists($this->temporaryDirectoryFullPath);
+    }
+
+    /** @test */
+    public function it_can_create_a_temporary_directory_with_a_name_using_execute()
+    {
+        $temporaryPath = '';
+
+        $result = (new TemporaryDirectory())
+            ->name($this->temporaryDirectory)
+            ->create()
+            ->execute(function (TemporaryDirectory $temporaryDirectory) use (&$temporaryPath) {
+                $this->assertDirectoryExists($temporaryPath = $temporaryDirectory->path());
+                $this->assertDirectoryExists($this->temporaryDirectoryFullPath);
+            });
+
+        $this->assertTrue($result);
+        $this->assertNotEmpty($temporaryPath);
+        $this->assertDirectoryDoesNotExist($temporaryPath);
+        $this->assertDirectoryDoesNotExist($this->temporaryDirectoryFullPath);
     }
 
     /** @test */


### PR DESCRIPTION
Implements a fast-way to create, use and delete a temporary directory like so:
```php
(new TemporaryDirectory())
     ->execute(fn ($tempDir) => noop($tempDir));
```

or

```php
(new TemporaryDirectory())
     ->name('your-dir-name')
     ->execute(fn ($tempDir) => noop($tempDir));
```

`Execute` will return the `delete()` `bool` return value.