### PR TITLE
Add a function to check if the temporary directory exist without catching PathAlreadyExists exception

### DIFF
--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -38,7 +38,7 @@ class TemporaryDirectory
             $this->deleteDirectory($this->getFullPath());
         }
 
-        if (file_exists($this->getFullPath())) {
+        if ($this->exists()) {
             throw PathAlreadyExists::create($this->getFullPath());
         }
 
@@ -97,6 +97,11 @@ class TemporaryDirectory
     public function delete(): bool
     {
         return $this->deleteDirectory($this->getFullPath());
+    }
+
+    public function exists(): bool
+    {
+        return file_exists($this->getFullPath());
     }
 
     protected function getFullPath(): string

--- a/tests/TemporaryDirectoryTest.php
+++ b/tests/TemporaryDirectoryTest.php
@@ -280,6 +280,19 @@ class TemporaryDirectoryTest extends TestCase
         $this->assertTrue($temporaryDirectory);
     }
 
+    /** @test */
+    public function it_exists_function_should_tell_if_directory_exists()
+    {
+        $temporaryDirectory = (new TemporaryDirectory())
+            ->name($this->temporaryDirectory);
+
+        $this->assertFalse($temporaryDirectory->exists());
+
+        $temporaryDirectory->create();
+
+        $this->assertTrue($temporaryDirectory->exists());
+    }
+
     protected function deleteDirectory(string $path): bool
     {
         if (is_link($path)) {


### PR DESCRIPTION
I would argue that there is a usecase where a "temporary" folder with files can be reused between request for some basic local caching. This is already possible with the PathAlreadyExists exception but I think it would give the users of this library a better developer experience if they could write code like this


```
$workingDirectory = (new TemporaryDirectory())
    ->name(md5($cachedContent));

if (!$workingDirectory->exists()) {
   $workingDirectory->create();
}
```

Instead of this
```
$workingDirectory = (new TemporaryDirectory())
    ->name(md5($cachedContent]));

try {
    $workingDirectory->create();
} catch (PathAlreadyExists $e) {
    // Do nothing, folder already exists
    // We can continue
}
```
So this PR exposes a simple exists() function