### PR TITLE
Setting to delete when an object is destroyed

### DIFF
--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -15,6 +15,8 @@ class TemporaryDirectory
 
     protected bool $forceCreate = false;
 
+    protected bool $deleteWhenDestroyed = false;
+
     public function __construct(string $location = '')
     {
         $this->location = $this->sanitizePath($location);
@@ -180,6 +182,20 @@ class TemporaryDirectory
             return rmdir($path);
         } catch (Throwable $throwable) {
             return false;
+        }
+    }
+
+    public function deleteWhenDestroyed(bool $deleteWhenDestroyed = true): self
+    {
+        $this->deleteWhenDestroyed = $deleteWhenDestroyed;
+
+        return $this;
+    }
+
+    public function __destruct()
+    {
+        if ($this->deleteWhenDestroyed) {
+            $this->delete();
         }
     }
 }

--- a/tests/TemporaryDirectoryTest.php
+++ b/tests/TemporaryDirectoryTest.php
@@ -293,6 +293,20 @@ class TemporaryDirectoryTest extends TestCase
         $this->assertTrue($temporaryDirectory->exists());
     }
 
+    /** @test */
+    public function it_can_delete_when_object_is_destroyed()
+    {
+        $temporaryDirectory = (new TemporaryDirectory())
+            ->name($this->temporaryDirectory)
+            ->deleteWhenDestroyed()
+            ->create();
+
+        $this->assertDirectoryExists($fullPath = $temporaryDirectory->path());
+
+        unset($temporaryDirectory);
+        $this->assertDirectoryDoesNotExist($fullPath);
+    }
+
     protected function deleteDirectory(string $path): bool
     {
         if (is_link($path)) {

--- a/tests/TemporaryDirectoryTest.php
+++ b/tests/TemporaryDirectoryTest.php
@@ -301,7 +301,9 @@ class TemporaryDirectoryTest extends TestCase
             ->deleteWhenDestroyed()
             ->create();
 
-        $this->assertDirectoryExists($fullPath = $temporaryDirectory->path());
+        $fullPath = $temporaryDirectory->path();
+
+        $this->assertDirectoryExists($fullPath);
 
         unset($temporaryDirectory);
         $this->assertDirectoryDoesNotExist($fullPath);


### PR DESCRIPTION
I know that there was a [similar PR](https://github.com/spatie/temporary-directory/pull/49) for for this a few years ago, but I figured I'd take a run at it.

This is not a breaking change. This adds a simple property so that the directory is deleted when `__destruct()` is called (which of course happens when the object is out of scope, the application ends, or the user calls `unset()` on a TemporaryDirectory instance).

```php
function copyFiles(string $directoryName) {
    $temporaryDirectory = (new TemporaryDirectory('/tmp/'))
        ->name($directoryName)
        ->deleteWhenDestroyed()
        ->create();

    // ... do cool stuff with that temporary directory
}

copyFiles('this-will-be-gone');

file_exists('/tmp/this-will-be-gone'); // false
```

