### PR TITLE
Remove unused variable in catch block

### DIFF
--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -178,7 +178,7 @@ class TemporaryDirectory
             gc_collect_cycles();
 
             return rmdir($path);
-        } catch (Throwable $throwable) {
+        } catch (Throwable) {
             return false;
         }
     }


### PR DESCRIPTION
# Changed log

- Removing the unused variable in the catch block and the reference is available [here](https://wiki.php.net/rfc/non-capturing_catches).