### PR TITLE
Using the random_int to replace mt_rand function

### DIFF
--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -32,7 +32,7 @@ class TemporaryDirectory
         }
 
         if (empty($this->name)) {
-            $this->name = mt_rand().'-'.str_replace([' ', '.'], '', microtime());
+            $this->name = random_int(0, mt_getrandmax()).'-'.str_replace([' ', '.'], '', microtime());
         }
 
         if ($this->forceCreate && file_exists($this->getFullPath())) {


### PR DESCRIPTION
# Changed log

- Since the `PHP 7.0` version, it should replace the `mt_rand` function with the `random_int` function.