### PR TITLE
added functionality for callbacks before/after create/delete

### DIFF
--- a/src/HasLifeCycleEvents.php
+++ b/src/HasLifeCycleEvents.php
@@ -1,0 +1,115 @@
+<?php
+namespace Spatie\TemporaryDirectory;
+use Illuminate\Support\Facades\App;
+
+trait HasLifeCycleEvents
+{
+    protected $beforeCreateCallbacks = [];
+
+    protected $afterCreateCallbacks = [];
+    protected $beforeDeleteCallbacks = [];
+    protected $afterDeleteCallbacks = [];
+
+    public function callBeforeCreateCallbacks(): void
+    {
+
+        foreach ($this->beforeCreateCallbacks as $callback) {
+            if (is_callable($callback)) {
+                $callback($this);
+            }
+        }
+    }
+
+    public function callAfterCreateCallbacks(): void
+    {
+
+        foreach ($this->afterCreateCallbacks as $callback) {
+            if (is_callable($callback)) {
+                $callback($this);
+            }
+        }
+    }
+
+    public function callBeforeDeleteCallbacks(): void
+    {
+
+        foreach ($this->beforeDeleteCallbacks as $callback) {
+            if (is_callable($callback)) {
+                $callback($this);
+            }
+        }
+    }
+
+    public function callAfterDeleteCallbacks(): void
+    {
+
+        foreach ($this->afterDeleteCallbacks as $callback) {
+            if (is_callable($callback)) {
+                $callback($this);
+            }
+        }
+    }
+
+
+
+    public function beforeCreate(array|callable $callback): object
+    {
+        if (!is_array($callback)) {
+            $callback = [$callback];
+        }
+
+        foreach ($callback as $item) {
+            if (is_callable($item)) {
+                $this->beforeCreateCallbacks[] = $item;
+            }
+        }
+
+        return $this;
+    }
+
+    public function afterCreate(array|callable $callback): object
+    {
+        if (!is_array($callback)) {
+            $callback = [$callback];
+        }
+
+        foreach ($callback as $item) {
+            if (is_callable($item)) {
+                $this->afterCreateCallbacks[] = $item;
+            }
+        }
+
+        return $this;
+    }
+
+    public function afterDelete(array|callable $callback): object
+    {
+        if (!is_array($callback)) {
+            $callback = [$callback];
+        }
+
+        foreach ($callback as $item) {
+            if (is_callable($item)) {
+                $this->afterDeleteCallbacks[] = $item;
+            }
+        }
+
+        return $this;
+    }
+
+    public function beforeDelete(array|callable $callback): object
+    {
+        if (!is_array($callback)) {
+            $callback = [$callback];
+        }
+
+        foreach ($callback as $item) {
+            if (is_callable($item)) {
+                $this->beforeDeleteCallbacks[] = $item;
+            }
+        }
+
+        return $this;
+    }
+
+}

--- a/src/HasLifeCycleEvents.php
+++ b/src/HasLifeCycleEvents.php
@@ -1,6 +1,6 @@
 <?php
+
 namespace Spatie\TemporaryDirectory;
-use Illuminate\Support\Facades\App;
 
 trait HasLifeCycleEvents
 {
@@ -50,11 +50,9 @@ trait HasLifeCycleEvents
         }
     }
 
-
-
     public function beforeCreate(array|callable $callback): object
     {
-        if (!is_array($callback)) {
+        if (! is_array($callback)) {
             $callback = [$callback];
         }
 
@@ -69,7 +67,7 @@ trait HasLifeCycleEvents
 
     public function afterCreate(array|callable $callback): object
     {
-        if (!is_array($callback)) {
+        if (! is_array($callback)) {
             $callback = [$callback];
         }
 
@@ -84,7 +82,7 @@ trait HasLifeCycleEvents
 
     public function afterDelete(array|callable $callback): object
     {
-        if (!is_array($callback)) {
+        if (! is_array($callback)) {
             $callback = [$callback];
         }
 
@@ -99,7 +97,7 @@ trait HasLifeCycleEvents
 
     public function beforeDelete(array|callable $callback): object
     {
-        if (!is_array($callback)) {
+        if (! is_array($callback)) {
             $callback = [$callback];
         }
 
@@ -111,5 +109,4 @@ trait HasLifeCycleEvents
 
         return $this;
     }
-
 }

--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -3,9 +3,9 @@
 namespace Spatie\TemporaryDirectory;
 
 use FilesystemIterator;
+use RuntimeException;
 use Spatie\TemporaryDirectory\Exceptions\InvalidDirectoryName;
 use Spatie\TemporaryDirectory\Exceptions\PathAlreadyExists;
-use RuntimeException;
 use Throwable;
 
 class TemporaryDirectory
@@ -66,7 +66,7 @@ class TemporaryDirectory
 
     protected function getFullPath(): string
     {
-        return $this->location . (!empty($this->name) ? DIRECTORY_SEPARATOR . $this->name : '');
+        return $this->location . (! empty($this->name) ? DIRECTORY_SEPARATOR . $this->name : '');
     }
 
     protected function deleteDirectory(string $path): bool
@@ -74,20 +74,22 @@ class TemporaryDirectory
         try {
             if (is_link($path)) {
                 $result = unlink($path);
+
                 return $result;
             }
 
-            if (!file_exists($path)) {
+            if (! file_exists($path)) {
                 return true;
             }
 
-            if (!is_dir($path)) {
+            if (! is_dir($path)) {
                 $result = unlink($path);
+
                 return $result;
             }
 
             foreach (new FilesystemIterator($path) as $item) {
-                if (!$this->deleteDirectory($item)) {
+                if (! $this->deleteDirectory($item)) {
                     return false;
                 }
             }
@@ -120,6 +122,7 @@ class TemporaryDirectory
         if ($this->useLifecycleEvents) {
             $this->callAfterDeleteCallbacks();
         }
+
         return true;
     }
 
@@ -130,11 +133,11 @@ class TemporaryDirectory
 
     public function mkdir($directoryPath, $mode = 0777, $recursive = true)
     {
-        if (!file_exists($directoryPath)) {
+        if (! file_exists($directoryPath)) {
             if ($this->useLifecycleEvents) {
                 $this->callBeforeCreateCallbacks();
             }
-            if (!mkdir($directoryPath, 0777, true) && !is_dir($directoryPath)) {
+            if (! mkdir($directoryPath, 0777, true) && ! is_dir($directoryPath)) {
                 throw new RuntimeException(sprintf('Directory "%s" was not created', $directoryPath));
             }
             if ($this->useLifecycleEvents) {
@@ -148,6 +151,7 @@ class TemporaryDirectory
     public function useLifecycleEvents(bool $useLifecycleEvents = true): TemporaryDirectory
     {
         $this->useLifecycleEvents = $useLifecycleEvents;
+
         return $this;
     }
 
@@ -167,7 +171,7 @@ class TemporaryDirectory
 
     protected function sanitizeName(string $name): string
     {
-        if (!$this->isValidDirectoryName($name)) {
+        if (! $this->isValidDirectoryName($name)) {
             throw InvalidDirectoryName::create($name);
         }
 
@@ -196,7 +200,7 @@ class TemporaryDirectory
 
         $directoryPath = $this->removeFilenameFromPath($path);
 
-        if (!file_exists($directoryPath)) {
+        if (! file_exists($directoryPath)) {
             $this->mkdir($directoryPath, 0777, true);
         }
 
@@ -205,7 +209,7 @@ class TemporaryDirectory
 
     protected function removeFilenameFromPath(string $path): string
     {
-        if (!$this->isFilePath($path)) {
+        if (! $this->isFilePath($path)) {
             return $path;
         }
 

--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -3,8 +3,9 @@
 namespace Spatie\TemporaryDirectory;
 
 use FilesystemIterator;
-use Exceptions\InvalidDirectoryName;
-use Exceptions\PathAlreadyExists;
+use Spatie\TemporaryDirectory\Exceptions\InvalidDirectoryName;
+use Spatie\TemporaryDirectory\Exceptions\PathAlreadyExists;
+use RuntimeException;
 use Throwable;
 
 class TemporaryDirectory
@@ -106,8 +107,7 @@ class TemporaryDirectory
                 $this->callBeforeCreateCallbacks();
             }
             if (!mkdir($directoryPath, 0777, true) && !is_dir($directoryPath)) {
-               error_log("Directory $directoryPath was not created");
-                // throw new \RuntimeException(sprintf('Directory "%s" was not created', $directoryPath));
+                throw new RuntimeException(sprintf('Directory "%s" was not created', $directoryPath));
             }
             if ($this->useLifecycleEvents) {
                 $this->callAfterCreateCallbacks();

--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -17,12 +17,18 @@ class TemporaryDirectory
     protected string $name = '';
     protected bool $useLifecycleEvents = false;
     protected bool $forceCreate = false;
-
     protected bool $deleteWhenDestroyed = false;
 
     public function __construct(string $location = '')
     {
         $this->location = $this->sanitizePath($location);
+    }
+
+    protected function sanitizePath(string $path): string
+    {
+        $path = rtrim($path);
+
+        return rtrim($path, DIRECTORY_SEPARATOR);
     }
 
     public static function make(string $location = ''): self
@@ -53,6 +59,98 @@ class TemporaryDirectory
         return $this;
     }
 
+    protected function getSystemTemporaryDirectory(): string
+    {
+        return rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR);
+    }
+
+    protected function getFullPath(): string
+    {
+        return $this->location . (!empty($this->name) ? DIRECTORY_SEPARATOR . $this->name : '');
+    }
+
+    protected function deleteDirectory(string $path): bool
+    {
+        try {
+            if (is_link($path)) {
+                $result = unlink($path);
+                return $result;
+            }
+
+            if (!file_exists($path)) {
+                return true;
+            }
+
+            if (!is_dir($path)) {
+                $result = unlink($path);
+                return $result;
+            }
+
+            foreach (new FilesystemIterator($path) as $item) {
+                if (!$this->deleteDirectory($item)) {
+                    return false;
+                }
+            }
+
+            /*
+             * By forcing a php garbage collection cycle using gc_collect_cycles() we can ensure
+             * that the rmdir does not fail due to files still being reserved in memory.
+             */
+            gc_collect_cycles();
+
+            return $this->rmdir($path);
+
+
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    public function rmdir($path)
+    {
+        if (file_exists($path) === false || is_dir($path) === false) {
+            throw new DirectoryNotFoundException("Directory $path not found");
+        }
+        if ($this->useLifecycleEvents) {
+            $this->callBeforeDeleteCallbacks();
+        }
+        if (false === rmdir($path)) {
+            throw new RuntimeException(sprintf('Directory "%s" was not deleted', $path));
+        }
+        if ($this->useLifecycleEvents) {
+            $this->callAfterDeleteCallbacks();
+        }
+        return true;
+    }
+
+    public function exists(): bool
+    {
+        return file_exists($this->getFullPath());
+    }
+
+    public function mkdir($directoryPath, $mode = 0777, $recursive = true)
+    {
+        if (!file_exists($directoryPath)) {
+            if ($this->useLifecycleEvents) {
+                $this->callBeforeCreateCallbacks();
+            }
+            if (!mkdir($directoryPath, 0777, true) && !is_dir($directoryPath)) {
+                throw new RuntimeException(sprintf('Directory "%s" was not created', $directoryPath));
+            }
+            if ($this->useLifecycleEvents) {
+                $this->callAfterCreateCallbacks();
+            }
+        } else {
+            throw new DirectoryAlreadyExistsException("Directory $directoryPath already exists");
+        }
+    }
+
+    public function useLifecycleEvents(bool $useLifecycleEvents = true): TemporaryDirectory
+    {
+        $this->useLifecycleEvents = $useLifecycleEvents;
+        return $this;
+    }
+
     public function force(): self
     {
         $this->forceCreate = true;
@@ -65,6 +163,20 @@ class TemporaryDirectory
         $this->name = $this->sanitizeName($name);
 
         return $this;
+    }
+
+    protected function sanitizeName(string $name): string
+    {
+        if (!$this->isValidDirectoryName($name)) {
+            throw InvalidDirectoryName::create($name);
+        }
+
+        return trim($name);
+    }
+
+    protected function isValidDirectoryName(string $directoryName): bool
+    {
+        return strpbrk($directoryName, '\\/?%*:|"<>') === false;
     }
 
     public function location(string $location): self
@@ -91,72 +203,6 @@ class TemporaryDirectory
         return $path;
     }
 
-    public function empty(): self
-    {
-        $this->deleteDirectory($this->getFullPath());
-
-        $this->mkdir($this->getFullPath(), 0777, true);
-
-        return $this;
-    }
-
-    public function mkdir($directoryPath, $mode = 0777, $recursive = true)
-    {
-        if (!file_exists($directoryPath)) {
-            if ($this->useLifecycleEvents) {
-                $this->callBeforeCreateCallbacks();
-            }
-            if (!mkdir($directoryPath, 0777, true) && !is_dir($directoryPath)) {
-                throw new RuntimeException(sprintf('Directory "%s" was not created', $directoryPath));
-            }
-            if ($this->useLifecycleEvents) {
-                $this->callAfterCreateCallbacks();
-            }
-        }
-
-    }
-
-    public function delete(): bool
-    {
-        return $this->deleteDirectory($this->getFullPath());
-    }
-
-    public function exists(): bool
-    {
-        return file_exists($this->getFullPath());
-    }
-
-    protected function getFullPath(): string
-    {
-        return $this->location . (!empty($this->name) ? DIRECTORY_SEPARATOR . $this->name : '');
-    }
-
-    protected function isValidDirectoryName(string $directoryName): bool
-    {
-        return strpbrk($directoryName, '\\/?%*:|"<>') === false;
-    }
-
-    protected function getSystemTemporaryDirectory(): string
-    {
-        return rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR);
-    }
-
-    protected function sanitizePath(string $path): string
-    {
-        $path = rtrim($path);
-
-        return rtrim($path, DIRECTORY_SEPARATOR);
-    }
-
-    protected function sanitizeName(string $name): string
-    {
-        if (!$this->isValidDirectoryName($name)) {
-            throw InvalidDirectoryName::create($name);
-        }
-
-        return trim($name);
-    }
-
     protected function removeFilenameFromPath(string $path): string
     {
         if (!$this->isFilePath($path)) {
@@ -171,58 +217,13 @@ class TemporaryDirectory
         return str_contains($path, '.');
     }
 
-    protected function deleteDirectory(string $path): bool
+    public function empty(): self
     {
-        try {
-            if (is_link($path)) {
-                if ($this->useLifecycleEvents) {
-                    $this->callBeforeDeleteCallbacks();
-                }
-                $result= unlink($path);
-                if ($this->useLifecycleEvents) {
-                    $this->callAfterDeleteCallbacks();
-                }
-                return $result;
-            }
+        $this->deleteDirectory($this->getFullPath());
 
-            if (!file_exists($path)) {
-                return true;
-            }
+        $this->mkdir($this->getFullPath(), 0777, true);
 
-            if (!is_dir($path)) {
-                if ($this->useLifecycleEvents) {
-                    $this->callBeforeDeleteCallbacks();
-                }
-                $result= unlink($path);
-                if ($this->useLifecycleEvents) {
-                    $this->callAfterDeleteCallbacks();
-                }
-
-                return $result;
-            }
-
-            foreach (new FilesystemIterator($path) as $item) {
-                if (!$this->deleteDirectory($item)) {
-                    return false;
-                }
-            }
-
-            /*
-             * By forcing a php garbage collection cycle using gc_collect_cycles() we can ensure
-             * that the rmdir does not fail due to files still being reserved in memory.
-             */
-            gc_collect_cycles();
-            if ($this->useLifecycleEvents) {
-                $this->callBeforeDeleteCallbacks();
-            }
-            $result= rmdir($path);
-            if ($this->useLifecycleEvents) {
-                $this->callAfterDeleteCallbacks();
-            }
-            return $result;
-        } catch (Throwable) {
-            return false;
-        }
+        return $this;
     }
 
     public function deleteWhenDestroyed(bool $deleteWhenDestroyed = true): self
@@ -237,5 +238,10 @@ class TemporaryDirectory
         if ($this->deleteWhenDestroyed) {
             $this->delete();
         }
+    }
+
+    public function delete(): bool
+    {
+        return $this->deleteDirectory($this->getFullPath());
     }
 }

--- a/tests/HasLifeCycleEventsTest.php
+++ b/tests/HasLifeCycleEventsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\TemporaryDirectory\HasLifeCycleEvents;
+
+class HasLifeCycleEventsTest extends TestCase
+{
+    use HasLifeCycleEvents;
+
+    public static $callbackCalled = false;
+    public static $randomStringForTest = "asd";
+    public $callback;
+
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->callback = static function ($instance) {
+            // make sure its being runned, really, really sure.
+            $instance::$randomStringForTest = substr(md5(microtime()), 0, 5);
+            $instance::$callbackCalled = true;
+        };
+    }
+
+    public function testCallBeforeCreateCallbacks(): void
+    {
+        self::$callbackCalled = false;
+        $this->beforeCreate($this->callback);
+        $this->callBeforeCreateCallbacks();
+        $this->assertTrue(self::$callbackCalled);
+        self::assertMatchesRegularExpression('/^[a-z0-9]{5}$/', self::$randomStringForTest);
+
+    }
+
+    public function testCallAfterCreateCallbacks(): void
+    {
+        self::$callbackCalled = false;
+
+        $this->afterCreate($this->callback);
+        $this->callAfterCreateCallbacks();
+        $this->assertTrue(self::$callbackCalled);
+        self::assertMatchesRegularExpression('/^[a-z0-9]{5}$/', self::$randomStringForTest);
+
+    }
+
+    public function testCallBeforeDeleteCallbacks(): void
+    {
+        self::$callbackCalled = false;
+
+        $this->beforeCreate($this->callback);
+        $this->callBeforeCreateCallbacks();
+        $this->assertTrue(self::$callbackCalled);
+        self::assertMatchesRegularExpression('/^[a-z0-9]{5}$/', self::$randomStringForTest);
+
+    }
+
+    public function testCallAfterDeleteCallbacks(): void
+    {
+        self::$callbackCalled = false;
+
+        $this->afterCreate($this->callback);
+        $this->callAfterCreateCallbacks();
+        $this->assertTrue(self::$callbackCalled);
+        self::assertMatchesRegularExpression('/^[a-z0-9]{5}$/', self::$randomStringForTest);
+
+    }
+}

--- a/tests/HasLifeCycleEventsTest.php
+++ b/tests/HasLifeCycleEventsTest.php
@@ -13,7 +13,6 @@ class HasLifeCycleEventsTest extends TestCase
     public static $randomStringForTest = "asd";
     public $callback;
 
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/TemporaryDirectoryTest.php
+++ b/tests/TemporaryDirectoryTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Spatie\TemporaryDirectory\Test;
+namespace Test;
 
 use FilesystemIterator;
 use PHPUnit\Framework\TestCase;
-use Spatie\TemporaryDirectory\Exceptions\InvalidDirectoryName;
-use Spatie\TemporaryDirectory\Exceptions\PathAlreadyExists;
-use Spatie\TemporaryDirectory\TemporaryDirectory;
+use Exceptions\InvalidDirectoryName;
+use TemporaryDirectory;
 
 class TemporaryDirectoryTest extends TestCase
 {

--- a/tests/TemporaryDirectoryTest.php
+++ b/tests/TemporaryDirectoryTest.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace Test;
+namespace Spatie\TemporaryDirectory\Test;
 
 use FilesystemIterator;
 use PHPUnit\Framework\TestCase;
-use Exceptions\InvalidDirectoryName;
-use TemporaryDirectory;
+use Spatie\TemporaryDirectory\Exceptions\InvalidDirectoryName;
+use Spatie\TemporaryDirectory\Exceptions\PathAlreadyExists;
+use Spatie\TemporaryDirectory\TemporaryDirectory;
 
 class TemporaryDirectoryTest extends TestCase
 {


### PR DESCRIPTION
This makes some things when for example setting up new projects or doing heavy backend processing like setting up or compiling or anything not supposed to last after their execution,

Not the best example, but to illiustrate usage: 
`App/Console/Commands/InstallCommand.php`
```
// file: App/Console/InstallCommand.php

private $commands=[
    'git clone xxx ',
    'wget somebigfile',
    'echo "installing stuff and unpacking somebigfile"'
];
function install()
{
    $temporaryDirectory = (new TemporaryDirectory())
        ->useLifecycleEvents()
        ->afterCreate(function($temporaryDirectory) {
            foreach($this->commands as $cmd) {
            Process::path($temporaryDirectory()->path())->run($cmd);
            }
    })->create();
}
```

Usage :
```
   $temporaryDirectory = (new TemporaryDirectory())->useLifecycleEvents()
        ->beforeCreate(function() { /*code to be executed*/ })
        ->afterCreate(function() { /*code to be executed*/ }
        ->beforeDelete(function() { /*code to be executed*/ })
        ->afterDelete(function() { /*code to be executed*/ })
``` 
Multiple functions can be chained:
```
   $temporaryDirectory = (new TemporaryDirectory())->useLifecycleEvents()
        ->beforeCreate(function() { /*code to be executed*/ })
        ->beforeCreate(function() { /*code to be executed*/ })
        ->beforeCreate(function() { /*code to be executed*/ })
``` 
or as an array of closures:
```
   $temporaryDirectory = (new TemporaryDirectory())->useLifecycleEvents()
        ->beforeCreate([
            function() { /*code to be executed*/ },
            function() { /*code to be executed*/ },
            function() { /*code to be executed*/ }
        ])->create();
``` 
