### PR TITLE
[2.x] Fix directories not being deleted in strict mode

### DIFF
--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -168,7 +168,7 @@ class TemporaryDirectory
             }
 
             foreach (new FilesystemIterator($path) as $item) {
-                if (! $this->deleteDirectory($item)) {
+                if (! $this->deleteDirectory((string) $item)) {
                     return false;
                 }
             }


### PR DESCRIPTION
This PR fixes the temporary directories not being deleted when strict mode is turned on.

This is caused by the `FileSystemIterator` yielding SplFileInfo objects which get implicitly cast to a string when strict mode is turned off. When turned on, it causes an invalid argument to be passed.

The exception then gets discarded.

This issue impacts [Laravel Backup](https://github.com/spatie/laravel-backup) and potentially others.

The first run will work just fine, the second run will fail with this error:

```
Starting backup...
Backup failed because: Path `/Users/MY_USERNAME/Projects/MY_PROJECT_NAME/storage/app/backup-temp/temp` already exists..
```

Calling `dd` on the exception reveals:

```
Starting backup...
TypeError {#3057
  #message: "Spatie\TemporaryDirectory\TemporaryDirectory::deleteDirectory(): Argument #1 ($path) must be of type string, SplFileInfo given, called in /Users/MY_USERNAME/Projects/MY_PROJECT_NAME/vendor/spatie/temporary-directory/src/TemporaryDirectory.php on line 173"
  #code: 0
  #file: "./vendor/spatie/temporary-directory/src/TemporaryDirectory.php"
  #line: 156
  trace: {
    ./vendor/spatie/temporary-directory/src/TemporaryDirectory.php:156 { …}
    ./vendor/spatie/temporary-directory/src/TemporaryDirectory.php:173 { …}
    ./vendor/spatie/temporary-directory/src/TemporaryDirectory.php:42 { …}
    ./vendor/spatie/laravel-backup/src/Tasks/Backup/BackupJob.php:142 { …}
    ./vendor/spatie/laravel-backup/src/Commands/BackupCommand.php:65 { …}
    ./vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:36 { …}
    ./vendor/laravel/framework/src/Illuminate/Container/Util.php:41 { …}
    ./vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:93 { …}
    ./vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:35 { …}
    ./vendor/laravel/framework/src/Illuminate/Container/Container.php:662 { …}
    ./vendor/laravel/framework/src/Illuminate/Console/Command.php:211 { …}
    ./vendor/symfony/console/Command/Command.php:326 { …}
    ./vendor/laravel/framework/src/Illuminate/Console/Command.php:180 { …}
    ./vendor/spatie/laravel-backup/src/Commands/BaseCommand.php:30 { …}
    ./vendor/symfony/console/Application.php:1096 { …}
    ./vendor/symfony/console/Application.php:324 { …}
    ./vendor/symfony/console/Application.php:175 { …}
    ./vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:201 { …}
    ./artisan:35 {
      ›
      › $status = $kernel->handle(
      ›     $input = new Symfony\Component\Console\Input\ArgvInput,
      arguments: {
        $input: Symfony\Component\Console\Input\ArgvInput {#29 …}
        $output: Symfony\Component\Console\Output\ConsoleOutput {#27 …}
      }
    }
  }
} // vendor/spatie/temporary-directory/src/TemporaryDirectory.php:186
```

By explicitly casting the SplFileInfo object to a string this also works in strict mode.