### PR TITLE
Return static instead of self

### DIFF
--- a/src/TemporaryDirectory.php
+++ b/src/TemporaryDirectory.php
@@ -19,17 +19,17 @@ class TemporaryDirectory
 
     protected int $permission = 0777;
 
-    public function __construct(string $location = '')
+    public final function __construct(string $location = '')
     {
         $this->location = $this->sanitizePath($location);
     }
 
-    public static function make(string $location = ''): self
+    public static function make(string $location = ''): static
     {
-        return (new self($location))->create();
+        return (new static($location))->create();
     }
 
-    public function create(): self
+    public function create(): static
     {
         if (empty($this->location)) {
             $this->location = $this->getSystemTemporaryDirectory();
@@ -52,28 +52,28 @@ class TemporaryDirectory
         return $this;
     }
 
-    public function force(): self
+    public function force(): static
     {
         $this->forceCreate = true;
 
         return $this;
     }
 
-    public function permission(int $permission): self
+    public function permission(int $permission): static
     {
         $this->permission = $permission;
 
         return $this;
     }
 
-    public function name(string $name): self
+    public function name(string $name): static
     {
         $this->name = $this->sanitizeName($name);
 
         return $this;
     }
 
-    public function location(string $location): self
+    public function location(string $location): static
     {
         $this->location = $this->sanitizePath($location);
 
@@ -97,7 +97,7 @@ class TemporaryDirectory
         return $path;
     }
 
-    public function empty(): self
+    public function empty(): static
     {
         $this->deleteDirectory($this->getFullPath());
 
@@ -199,7 +199,7 @@ class TemporaryDirectory
         }
     }
 
-    public function deleteWhenDestroyed(bool $deleteWhenDestroyed = true): self
+    public function deleteWhenDestroyed(bool $deleteWhenDestroyed = true): static
     {
         $this->deleteWhenDestroyed = $deleteWhenDestroyed;
 


### PR DESCRIPTION
## Use `static` return types to support inheritance

This PR replaces `self` with `static` in all return type declarations and factory calls across `TemporaryDirectory`, making the class properly extensible.

### Changes

- `make()` uses `new static()` instead of `new self()` and returns `static`
- Constructor is marked `final` to guarantee LSP compliance

### Why

Currently, extending `TemporaryDirectory` breaks the fluent API, every chained method returns the parent type, losing the child class.